### PR TITLE
Fix Navigation logic in AnnotationView

### DIFF
--- a/IOSAccessAssessment/Camera/CameraManager.swift
+++ b/IOSAccessAssessment/Camera/CameraManager.swift
@@ -19,6 +19,7 @@ class CameraManager: ObservableObject, CaptureDataReceiver {
         }
     }
     // TODO: Currently, the orientation is redundant until we start using other orientation types
+    //  It does not seem to be used anywhere currently
     @Published var orientation = UIDevice.current.orientation
     @Published var processingCapturedResult = false
     @Published var dataAvailable = false

--- a/IOSAccessAssessment/Camera/CameraManager.swift
+++ b/IOSAccessAssessment/Camera/CameraManager.swift
@@ -51,6 +51,11 @@ class CameraManager: ObservableObject, CaptureDataReceiver {
         processingCapturedResult = false
     }
     
+    func stopStream() {
+        controller.stopStream()
+        processingCapturedResult = false
+    }
+    
     func onNewPhotoData() {
         processingCapturedResult = true
     }

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -9,76 +9,69 @@ import SwiftUI
 struct AnnotationView: View {
     @ObservedObject var sharedImageData: SharedImageData
     @State private var index = 0
-    @State private var selectedIndex: Int? = nil
     @State private var isShowingCameraView = false
+    
+    let options = ["I agree with this class annotation", "Annotation is missing some instances of the class", "The class annotation is misidentified"]
+    @State private var selectedOptionIndex: Int? = nil
     
     var objectLocation: ObjectLocation
     var selection: [Int]
     var classes: [String]
-    let options = ["I agree with this class annotation", "Annotation is missing some instances of the class", "The class annotation is misidentified"]
     
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
-        // TODO: Instead of adding the ContentView again to the NavigationStack,
-        //  it would be better to go to the previous screen in the NavigationStack once we are done with the AnnotationView
-        //  This way, if the ContentView is the previous view (in the current flow, it always is),
-        //  then we avoid having to recreate it again.
-//        if isShowingCameraView || index >= sharedImageData.classImages.count {
-//            ContentView(selection: Array(selection))
-//        } else {
-            ZStack {
-                VStack {
-                    HStack {
-                        Spacer()
-                        HostedAnnotationCameraViewController(sharedImageData: sharedImageData, index: index)
-                        Spacer()
-                    }
-                    HStack {
-                        Spacer()
-                        Text("Selected class: \(classes[selection[index]])")
-                        Spacer()
-                    }
-                    
-                    ProgressBar(value: calculateProgress())
-                    
-                    HStack {
-                        Spacer()
-                        VStack {
-                            ForEach(0..<options.count) { optionIndex in
-                                Button(action: {
-                                    // Toggle selection
-                                    if selectedIndex == optionIndex {
-                                        selectedIndex = nil
-                                    } else {
-                                        selectedIndex = optionIndex
-                                    }
-                                }) {
-                                    Text(options[optionIndex])
-                                        .padding()
-                                        .foregroundColor(selectedIndex == optionIndex ? .red : .blue) // Change color based on selection
+        ZStack {
+            VStack {
+                HStack {
+                    Spacer()
+                    HostedAnnotationCameraViewController(sharedImageData: sharedImageData, index: index)
+                    Spacer()
+                }
+                HStack {
+                    Spacer()
+                    Text("Selected class: \(classes[selection[index]])")
+                    Spacer()
+                }
+                
+                ProgressBar(value: calculateProgress())
+                
+                HStack {
+                    Spacer()
+                    VStack {
+                        ForEach(0..<options.count, id: \.self) { optionIndex in
+                            Button(action: {
+                                // Toggle selection
+                                if selectedOptionIndex == optionIndex {
+                                    selectedOptionIndex = nil
+                                } else {
+                                    selectedOptionIndex = optionIndex
                                 }
+                            }) {
+                                Text(options[optionIndex])
+                                    .padding()
+                                    .foregroundColor(selectedOptionIndex == optionIndex ? .red : .blue) // Change color based on selection
                             }
                         }
-                        Spacer()
                     }
-                    
-                    Button(action: {
-                        objectLocation.calcLocation(sharedImageData: sharedImageData, index: index)
-                        self.nextSegment()
-                        selectedIndex = nil
-                    }) {
-                        Text("Next")
-                    }
-                    .padding()
+                    Spacer()
                 }
+                
+                Button(action: {
+                    objectLocation.calcLocation(sharedImageData: sharedImageData, index: index)
+                    self.nextSegment()
+                    selectedOptionIndex = nil
+                }) {
+                    Text("Next")
+                }
+                .padding()
             }
-            .navigationBarTitle("Annotation View", displayMode: .inline)
-            .onChange(of: index) { _ in
-                // Trigger any additional actions when the index changes
-                self.refreshView()
-            }
-//        }
+        }
+        .navigationBarTitle("Annotation View", displayMode: .inline)
+        .onChange(of: index) { _ in
+            // Trigger any additional actions when the index changes
+            self.refreshView()
+        }
     }
     
     func nextSegment() {
@@ -93,7 +86,7 @@ struct AnnotationView: View {
 
     func refreshView() {
         // Any additional refresh logic can be placed here
-        // Example: fetching new data, triggering animations, etc.
+        // Example: fetching new data, triggering animations, sending current data etc.
     }
 
     func calculateProgress() -> Float {

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -17,14 +17,16 @@ struct AnnotationView: View {
     var classes: [String]
     let options = ["I agree with this class annotation", "Annotation is missing some instances of the class", "The class annotation is misidentified"]
     
+    @Environment(\.dismiss) var dismiss
+    
     var body: some View {
         // TODO: Instead of adding the ContentView again to the NavigationStack,
         //  it would be better to go to the previous screen in the NavigationStack once we are done with the AnnotationView
         //  This way, if the ContentView is the previous view (in the current flow, it always is),
         //  then we avoid having to recreate it again.
-        if isShowingCameraView || index >= sharedImageData.classImages.count {
-            ContentView(selection: Array(selection))
-        } else {
+//        if isShowingCameraView || index >= sharedImageData.classImages.count {
+//            ContentView(selection: Array(selection))
+//        } else {
             ZStack {
                 VStack {
                     HStack {
@@ -43,18 +45,18 @@ struct AnnotationView: View {
                     HStack {
                         Spacer()
                         VStack {
-                            ForEach(0..<options.count) { index in
+                            ForEach(0..<options.count) { optionIndex in
                                 Button(action: {
                                     // Toggle selection
-                                    if selectedIndex == index {
+                                    if selectedIndex == optionIndex {
                                         selectedIndex = nil
                                     } else {
-                                        selectedIndex = index
+                                        selectedIndex = optionIndex
                                     }
                                 }) {
-                                    Text(options[index])
+                                    Text(options[optionIndex])
                                         .padding()
-                                        .foregroundColor(selectedIndex == index ? .red : .blue) // Change color based on selection
+                                        .foregroundColor(selectedIndex == optionIndex ? .red : .blue) // Change color based on selection
                                 }
                             }
                         }
@@ -72,29 +74,21 @@ struct AnnotationView: View {
                 }
             }
             .navigationBarTitle("Annotation View", displayMode: .inline)
-//            .navigationBarBackButtonHidden(true)
-//            .navigationBarItems(leading: Button(action: {
-//                // This action depends on how you manage navigation
-//                // For demonstration, this simply dismisses the view, but you need a different mechanism to navigate to CameraView
-//                self.isShowingCameraView = true;
-//            }) {
-//                Image(systemName: "chevron.left")
-//                    .foregroundColor(.blue)
-//                Text("Camera View")
-//            })
             .onChange(of: index) { _ in
                 // Trigger any additional actions when the index changes
                 self.refreshView()
             }
-        }
+//        }
     }
     
     func nextSegment() {
-        self.index += 1
-        if self.index >= (sharedImageData.classImages.count) {
+        if (self.index + 1) >= (sharedImageData.classImages.count) {
             // Handle completion, save responses, or navigate to the next screen
-            ContentView(selection: Array(selection))
+//            ContentView(selection: Array(selection))
+            self.dismiss()
+            return
         }
+        self.index += 1
     }
 
     func refreshView() {

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -11,7 +11,7 @@ struct AnnotationView: View {
     @State private var index = 0
     @State private var selectedIndex: Int? = nil
     @State private var isShowingCameraView = false
-    @State private var isUpdatingSegmentation = false
+    
     var objectLocation: ObjectLocation
     var selection: [Int]
     var classes: [String]
@@ -22,7 +22,7 @@ struct AnnotationView: View {
         //  it would be better to go to the previous screen in the NavigationStack once we are done with the AnnotationView
         //  This way, if the ContentView is the previous view (in the current flow, it always is),
         //  then we avoid having to recreate it again.
-        if isShowingCameraView || self.index >= sharedImageData.classImages.count {
+        if isShowingCameraView || index >= sharedImageData.classImages.count {
             ContentView(selection: Array(selection))
         } else {
             ZStack {
@@ -69,20 +69,19 @@ struct AnnotationView: View {
                         Text("Next")
                     }
                     .padding()
-                    .disabled(isUpdatingSegmentation)
                 }
             }
             .navigationBarTitle("Annotation View", displayMode: .inline)
-            .navigationBarBackButtonHidden(true)
-            .navigationBarItems(leading: Button(action: {
-                // This action depends on how you manage navigation
-                // For demonstration, this simply dismisses the view, but you need a different mechanism to navigate to CameraView
-                self.isShowingCameraView = true;
-            }) {
-                Image(systemName: "chevron.left")
-                    .foregroundColor(.blue)
-                Text("Camera View")
-            })
+//            .navigationBarBackButtonHidden(true)
+//            .navigationBarItems(leading: Button(action: {
+//                // This action depends on how you manage navigation
+//                // For demonstration, this simply dismisses the view, but you need a different mechanism to navigate to CameraView
+//                self.isShowingCameraView = true;
+//            }) {
+//                Image(systemName: "chevron.left")
+//                    .foregroundColor(.blue)
+//                Text("Camera View")
+//            })
             .onChange(of: index) { _ in
                 // Trigger any additional actions when the index changes
                 self.refreshView()

--- a/IOSAccessAssessment/Views/ContentView.swift
+++ b/IOSAccessAssessment/Views/ContentView.swift
@@ -98,10 +98,12 @@ struct ContentView: View {
 //                    sharedImageData.updateSegmentation = { index in
 //                        self.manager?.segmentationController?.processSegmentationRequestPerClass()
 //                    }
+                } else {
+                    manager?.resumeStream()
                 }
             }
             .onDisappear {
-                manager?.controller.stopStream()
+                manager?.stopStream()
             }
     }
 }

--- a/IOSAccessAssessment/Views/ContentView.swift
+++ b/IOSAccessAssessment/Views/ContentView.swift
@@ -99,6 +99,8 @@ struct ContentView: View {
 //                        self.manager?.segmentationController?.processSegmentationRequestPerClass()
 //                    }
                 } else {
+                    // TODO: Need to check if simply resuming the stream is enough
+                    //  or do we have to re-initialize some other properties
                     manager?.resumeStream()
                 }
             }


### PR DESCRIPTION
Instead of creating a new ContentView instance every time we need to go back to it, we now pop the current AnnotationView from the navigation stack to return to the ContentView.