### PR TITLE
Add temporary fix on AnnotationView to handle automated navigation on…

### DIFF
--- a/IOSAccessAssessment/Views/ContentView.swift
+++ b/IOSAccessAssessment/Views/ContentView.swift
@@ -55,27 +55,20 @@ struct ContentView: View {
                         HostedCameraViewController(session: manager!.controller.captureSession)
                         HostedSegmentationViewController(sharedImageData: sharedImageData, selection: Array(selection), classes: Constants.ClassConstants.classes)
                     }
-                    // TODO: Check if we should update to NavigationDestination which is compatible with iOS 16+
-                    //  Warning: This will not work in iOS versions before 16
-                    NavigationLink(
-                        destination: AnnotationView(sharedImageData: sharedImageData, objectLocation: objectLocation, selection: sharedImageData.segmentedIndices, classes: Constants.ClassConstants.classes),
-                        isActive: $navigateToAnnotationView
-                    ) {
-                        Button {
-                            annotationView = true
-                            objectLocation.settingLocation()
-                            manager!.startPhotoCapture()
-                            // TODO: Instead of an arbitrary delay, we should have an event listener to the CameraManager
-                            // that triggers when the photo capture is completed
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                                navigateToAnnotationView = true
-                            }
-                        } label: {
-                            Image(systemName: "camera.circle.fill")
-                                .resizable()
-                                .frame(width: 60, height: 60)
-                                .foregroundColor(.white)
+                    Button {
+                        annotationView = true
+                        objectLocation.settingLocation()
+                        manager!.startPhotoCapture()
+                        // TODO: Instead of an arbitrary delay, we should have an event listener to the CameraManager
+                        // that triggers when the photo capture is completed
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            navigateToAnnotationView = true
                         }
+                    } label: {
+                        Image(systemName: "camera.circle.fill")
+                            .resizable()
+                            .frame(width: 60, height: 60)
+                            .foregroundColor(.white)
                     }
                 }
                 else {
@@ -86,9 +79,15 @@ struct ContentView: View {
                     }
                 }
             }
+            .navigationDestination(isPresented: $navigateToAnnotationView) {
+                AnnotationView(sharedImageData: sharedImageData, objectLocation: objectLocation, 
+                               selection: sharedImageData.segmentedIndices, classes: Constants.ClassConstants.classes
+                )
+            }
             .navigationBarTitle("Camera View", displayMode: .inline)
             .onAppear {
-                if manager == nil {
+                print("Is Manager Nil \(self.manager == nil)")
+                if (manager == nil) {
                     manager = CameraManager(sharedImageData: sharedImageData)
 //                    let segmentationController = SegmentationViewController(sharedImageData: sharedImageData)
 //                    segmentationController.selection = selection


### PR DESCRIPTION
… empty segments (#16)

* Streamline initial condition check in AnnotationView to load contents

* Utilize the streamlined condition check to eliminate redundant checks

* Replace NavigationLink with navigationDestination along with failed attempt to fix automatic navigation with no segments

* Revert fix attempts for back navigation on empty segments

* Temporary async dismiss fix to handle automated back navigation on empty segments