### PR TITLE
Work on Changesets in API transmission

### DIFF
--- a/IOSAccessAssessment.xcodeproj/project.pbxproj
+++ b/IOSAccessAssessment.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		55659C122BB786580094DF01 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55659C112BB786580094DF01 /* ContentView.swift */; };
 		55659C142BB786700094DF01 /* AnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55659C132BB786700094DF01 /* AnnotationView.swift */; };
 		55C2F2842C00078D00B633D7 /* ObjectLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C2F2832C00078D00B633D7 /* ObjectLocation.swift */; };
+		CA924A932CEB9AB000FCA928 /* ChangesetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA924A922CEB9AB000FCA928 /* ChangesetService.swift */; };
 		CAA947762CDE6FBD000C6918 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA947752CDE6FBB000C6918 /* LoginView.swift */; };
 		CAA947792CDE700A000C6918 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA947782CDE7007000C6918 /* AuthService.swift */; };
 		CAA9477B2CDE70D9000C6918 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA9477A2CDE70D5000C6918 /* KeychainService.swift */; };
@@ -71,6 +72,7 @@
 		55659C112BB786580094DF01 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		55659C132BB786700094DF01 /* AnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationView.swift; sourceTree = "<group>"; };
 		55C2F2832C00078D00B633D7 /* ObjectLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectLocation.swift; sourceTree = "<group>"; };
+		CA924A922CEB9AB000FCA928 /* ChangesetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesetService.swift; sourceTree = "<group>"; };
 		CAA947752CDE6FBB000C6918 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		CAA947782CDE7007000C6918 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		CAA9477A2CDE70D5000C6918 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 			children = (
 				CAA9477A2CDE70D5000C6918 /* KeychainService.swift */,
 				CAA947782CDE7007000C6918 /* AuthService.swift */,
+				CA924A922CEB9AB000FCA928 /* ChangesetService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -386,6 +389,7 @@
 				DAA7F8C02CA68400003666D8 /* SegmentationViewController.swift in Sources */,
 				DAA7F8BD2CA67A5A003666D8 /* CameraViewController.swift in Sources */,
 				55659C082BB785CB0094DF01 /* CameraController.swift in Sources */,
+				CA924A932CEB9AB000FCA928 /* ChangesetService.swift in Sources */,
 				DAA7F8C82CA76527003666D8 /* CIImageUtils.swift in Sources */,
 				55659C142BB786700094DF01 /* AnnotationView.swift in Sources */,
 				CAA947792CDE700A000C6918 /* AuthService.swift in Sources */,

--- a/IOSAccessAssessment/Services/ChangesetService.swift
+++ b/IOSAccessAssessment/Services/ChangesetService.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+struct NodeData {
+    let latitude: Double
+    let longitude: Double
+}
+
 class ChangesetService {
     
     private enum Constants {
@@ -64,7 +69,7 @@ class ChangesetService {
         }.resume()
     }
     
-    func uploadChanges(latitude: Double, longitude: Double, completion: @escaping (Result<Void, Error>) -> Void) {
+    func uploadChanges(nodeData: NodeData, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let changesetId,
               let accessToken,
               let url = URL(string: "\(Constants.baseUrl)/changeset/\(changesetId)/upload")
@@ -74,7 +79,7 @@ class ChangesetService {
         """
         <osmChange version="0.6" generator="GIG Change generator">
             <create>
-                <node id="-1" lat="\(latitude)" lon="\(longitude)" changeset="\(changesetId)" />
+                <node id="-1" lat="\(nodeData.latitude)" lon="\(nodeData.longitude)" changeset="\(changesetId)" />
             </create>
         </osmChange>
         """

--- a/IOSAccessAssessment/Services/ChangesetService.swift
+++ b/IOSAccessAssessment/Services/ChangesetService.swift
@@ -1,0 +1,69 @@
+//
+//  ChangesetService.swift
+//  IOSAccessAssessment
+//
+//  Created by Mariana Piz on 11.11.2024.
+//
+
+import Foundation
+
+class ChangesetService {
+    
+    private enum Constants {
+        static let baseUrl = "https://osm.workspaces-stage.sidewalks.washington.edu/api/0.6"
+        static let workspaceId = "168"
+    }
+    
+    static let shared = ChangesetService()
+    private init() {}
+    
+    private(set) var changesetId: String?
+    
+    func openChangeset(completion: @escaping (Result<String, Error>) -> Void) {
+        guard let url = URL(string: "\(Constants.baseUrl)/changeset/create"),
+              let accessToken = KeychainService().getValue(for: .accessToken) else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(Constants.workspaceId, forHTTPHeaderField: "X-Workspace")
+        request.setValue("application/xml", forHTTPHeaderField: "Content-Type")
+        
+        guard let xmlData = """
+            <osm>
+                <changeset>
+                    <tag k="created_by" v="GIG 1.0(4)" />
+                    <tag k="comment" v="iOS OSM client" />
+                </changeset>
+            </osm>
+            """
+            .data(using: .utf8)
+        else {
+            print("Failed to create XML data.")
+            return
+        }
+
+        request.httpBody = xmlData
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            if let data = data,
+                let changesetId = String(data: data, encoding: .utf8)
+            {
+                let changesetId = changesetId.trimmingCharacters(in: .whitespacesAndNewlines)
+                self.changesetId = changesetId
+                
+                completion(.success(changesetId))
+            } else {
+                completion(.failure(NSError(domain: "ChangesetError",
+                                            code: -1,
+                                            userInfo: [NSLocalizedDescriptionKey: "Failed to open changeset"])))
+            }
+        }.resume()
+    }
+    
+}

--- a/IOSAccessAssessment/Services/ChangesetService.swift
+++ b/IOSAccessAssessment/Services/ChangesetService.swift
@@ -51,12 +51,8 @@ class ChangesetService {
                 return
             }
             
-            if let data = data,
-                let changesetId = String(data: data, encoding: .utf8)
-            {
-                let changesetId = changesetId.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let data = data, let changesetId = String(data: data, encoding: .utf8) {
                 self.changesetId = changesetId
-                
                 completion(.success(changesetId))
             } else {
                 completion(.failure(NSError(domain: "ChangesetError",

--- a/IOSAccessAssessment/Services/ChangesetService.swift
+++ b/IOSAccessAssessment/Services/ChangesetService.swift
@@ -100,4 +100,25 @@ class ChangesetService {
         }.resume()
     }
     
+    func closeChangeset(completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let changesetId, let accessToken else { return }
+        
+        guard let url = URL(string: "\(Constants.baseUrl)/changeset/\(changesetId)/close") else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            self.changesetId = nil
+            
+            completion(.success(()))
+        }.resume()
+    }
+    
 }

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -157,7 +157,9 @@ struct AnnotationView: View {
               let nodeLongitude = objectLocation.longitude
         else { return }
         
-        ChangesetService.shared.uploadChanges(latitude: nodeLatitude, longitude: nodeLongitude) { result in
+        let nodeData = NodeData(latitude: nodeLatitude, longitude: nodeLongitude)
+        
+        ChangesetService.shared.uploadChanges(nodeData: nodeData) { result in
             switch result {
             case .success:
                 print("Changes uploaded successfully.")

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -90,6 +90,7 @@ struct AnnotationView: View {
                         objectLocation.calcLocation(sharedImageData: sharedImageData, index: index)
                         self.nextSegment()
                         selectedOption = nil
+                        uploadChanges()
                     }) {
                         Text("Next")
                     }
@@ -149,6 +150,21 @@ struct AnnotationView: View {
 
     func calculateProgress() -> Float {
         return Float(self.index) / Float(self.selection.count)
+    }
+    
+    private func uploadChanges() {
+        guard let nodeLatitude = objectLocation.latitude,
+              let nodeLongitude = objectLocation.longitude
+        else { return }
+        
+        ChangesetService.shared.uploadChanges(latitude: nodeLatitude, longitude: nodeLongitude) { result in
+            switch result {
+            case .success:
+                print("Changes uploaded successfully.")
+            case .failure(let error):
+                print("Failed to upload changes: \(error.localizedDescription)")
+            }
+        }
     }
 }
 

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -88,11 +88,16 @@ struct AnnotationView: View {
                     
                     Button(action: {
                         objectLocation.calcLocation(sharedImageData: sharedImageData, index: index)
-                        self.nextSegment()
                         selectedOption = nil
                         uploadChanges()
+                        
+                        if index == selection.count - 1 {
+                            closeChangeset()
+                        } else {
+                            nextSegment()
+                        }
                     }) {
-                        Text("Next")
+                        Text(index == selection.count - 1 ? "Finish" : "Next")
                     }
                     .padding()
                 }
@@ -168,6 +173,18 @@ struct AnnotationView: View {
             }
         }
     }
+    
+    private func closeChangeset() {
+        ChangesetService.shared.closeChangeset { result in
+            switch result {
+            case .success:
+                print("Changeset closed successfully.")
+            case .failure(let error):
+                print("Failed to close changeset: \(error.localizedDescription)")
+            }
+        }
+    }
+
 }
 
 struct ClassSelectionView: View {

--- a/IOSAccessAssessment/Views/ContentView.swift
+++ b/IOSAccessAssessment/Views/ContentView.swift
@@ -113,7 +113,6 @@ struct ContentView: View {
     }
     
     private func openChangeset() {
-        print("open a changeset")
         ChangesetService.shared.openChangeset { result in
             switch result {
             case .success(let changesetId):


### PR DESCRIPTION
According to the issue #84 : 

- Created ChangesetService:
   - Provides methods for opening a changeset, uploading changes, and closing a changeset;
   - Includes a changesetId property to track the currently opened changeset;
   - Implemented as a Singleton to be accessible in both ContentView and AnnotationView.

- Integrated ChangesetService in ContentView:
    - A changeset is opened when ContentView appears.

- Integrated ChangesetService in AnnotationView:
    - Changes are uploaded to the currently opened changeset when the user taps the "Next" button;
    - The changeset is closed after the user processes the last frame.

- Updated the button label in AnnotationView:
    - The "Next" button changes to "Finish" when the user reaches the last frame.
