### PR TITLE
Fix changesets

### DIFF
--- a/IOSAccessAssessment/Services/ChangesetService.swift
+++ b/IOSAccessAssessment/Services/ChangesetService.swift
@@ -39,8 +39,8 @@ class ChangesetService {
         guard let xmlData = """
             <osm>
                 <changeset>
-                    <tag k="created_by" v="GIG 1.0(4)" />
-                    <tag k="comment" v="iOS OSM client" />
+                    <tag k="created_by" v="iOSPointMapper" />
+                    <tag k="comment" v="" />
                 </changeset>
             </osm>
             """
@@ -77,7 +77,7 @@ class ChangesetService {
         
         let xmlContent =
         """
-        <osmChange version="0.6" generator="GIG Change generator">
+        <osmChange version="0.6" generator="iOSPointMapper Change generator">
             <create>
                 <node id="-1" lat="\(nodeData.latitude)" lon="\(nodeData.longitude)" changeset="\(changesetId)" />
             </create>

--- a/IOSAccessAssessment/Services/ChangesetService.swift
+++ b/IOSAccessAssessment/Services/ChangesetService.swift
@@ -41,7 +41,7 @@ class ChangesetService {
             <osm>
                 <changeset>
                     <tag k="created_by" v="iOSPointMapper" />
-                    <tag k="comment" v="" />
+                    <tag k="comment" v="iOS OSM client" />
                 </changeset>
             </osm>
             """

--- a/IOSAccessAssessment/Services/ChangesetService.swift
+++ b/IOSAccessAssessment/Services/ChangesetService.swift
@@ -10,6 +10,7 @@ import Foundation
 struct NodeData {
     let latitude: Double
     let longitude: Double
+    let tags: [String: String]
 }
 
 class ChangesetService {
@@ -75,11 +76,17 @@ class ChangesetService {
               let url = URL(string: "\(Constants.baseUrl)/changeset/\(changesetId)/upload")
         else { return }
         
+        let tagElements = nodeData.tags.map { key, value in
+            "<tag k=\"\(key)\" v=\"\(value)\" />"
+        }.joined(separator: "\n")
+        
         let xmlContent =
         """
         <osmChange version="0.6" generator="iOSPointMapper Change generator">
             <create>
-                <node id="-1" lat="\(nodeData.latitude)" lon="\(nodeData.longitude)" changeset="\(changesetId)" />
+                <node id="-1" lat="\(nodeData.latitude)" lon="\(nodeData.longitude)" changeset="\(changesetId)">
+                    \(tagElements)
+                </node>
             </create>
         </osmChange>
         """

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -96,12 +96,7 @@ struct AnnotationView: View {
                         objectLocation.calcLocation(sharedImageData: sharedImageData, index: index)
                         selectedOption = nil
                         uploadChanges()
-                        
-                        if index == selection.count - 1 {
-                            closeChangeset()
-                        } else {
-                            nextSegment()
-                        }
+                        nextSegment()
                     }) {
                         Text(index == selection.count - 1 ? "Finish" : "Next")
                     }
@@ -113,6 +108,9 @@ struct AnnotationView: View {
                 if (!self.isValid()) {
                     self.dismiss()
                 }
+            }
+            .onDisappear {
+                closeChangeset()
             }
             .onChange(of: index) { _ in
                 // Trigger any additional actions when the index changes

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -169,7 +169,11 @@ struct AnnotationView: View {
               let nodeLongitude = objectLocation.longitude
         else { return }
         
-        let nodeData = NodeData(latitude: nodeLatitude, longitude: nodeLongitude)
+        let tags = [
+           "footway": "sidewalk",
+           "surface": "concrete"
+        ]
+        let nodeData = NodeData(latitude: nodeLatitude, longitude: nodeLongitude, tags: tags)
         
         ChangesetService.shared.uploadChanges(nodeData: nodeData) { result in
             switch result {

--- a/IOSAccessAssessment/Views/AnnotationView.swift
+++ b/IOSAccessAssessment/Views/AnnotationView.swift
@@ -167,10 +167,7 @@ struct AnnotationView: View {
               let nodeLongitude = objectLocation.longitude
         else { return }
         
-        let tags = [
-           "footway": "sidewalk",
-           "surface": "concrete"
-        ]
+        let tags: [String: String] = [:]
         let nodeData = NodeData(latitude: nodeLatitude, longitude: nodeLongitude, tags: tags)
         
         ChangesetService.shared.uploadChanges(nodeData: nodeData) { result in


### PR DESCRIPTION
Made necessary fixes for changeset management:
- renamed "GIG 1.0(4)" to "iOSPointMapper" as the author of changes (left the comment "iOS OSM client", though, because the changes seem not to be pushed without it)
- enabled Retry option if a changeset was not opened successfully
- fixed closing changesets by doing it when Annotation View disappears
- added support for tags for nodes as dictionary [String: String] (attaching a screenshot from Postman to see the node with its tags)
<img width="317" alt="Screenshot 2024-12-16 at 19 32 15" src="https://github.com/user-attachments/assets/258f2aec-f780-45fb-843a-aa22903c27cd" />
